### PR TITLE
Add Javadoc to ListCommand and DispenseCommand

### DIFF
--- a/src/main/java/seedu/pharmatracker/command/DispenseCommand.java
+++ b/src/main/java/seedu/pharmatracker/command/DispenseCommand.java
@@ -7,18 +7,51 @@ import seedu.pharmatracker.data.Inventory;
 import seedu.pharmatracker.data.Medication;
 import seedu.pharmatracker.ui.Ui;
 
+/**
+ * Command that dispenses a specified quantity of a medication from the inventory.
+ *
+ * <p>The target medication is identified by a 1-based index. Dispensing fails
+ * if the index is out of range or if the requested quantity exceeds current stock,
+ * in both cases printing an error message and leaving the inventory unchanged.
+ */
 public class DispenseCommand extends Command {
+
+    /** Command keyword used to trigger this command. */
     public static final String COMMAND_WORD = "dispense";
+
     private static final Logger logger = Logger.getLogger(DispenseCommand.class.getName());
 
+    /** 1-based index of the medication to dispense from the inventory. */
     private final int index;
+
+    /** Number of units to dispense. */
     private final int quantity;
 
+    /**
+     * Constructs a {@code DispenseCommand} with the target medication index and quantity.
+     *
+     * @param index    1-based position of the medication in the inventory
+     * @param quantity number of units to dispense; must not exceed available stock
+     */
     public DispenseCommand(int index, int quantity) {
         this.index = index;
         this.quantity = quantity;
     }
 
+    /**
+     * Executes the dispense command, reducing the medication's stock by the specified quantity.
+     *
+     * <p>Prints an error and returns early under two conditions:
+     * <ul>
+     *   <li>The index is less than 1 or exceeds the inventory size.</li>
+     *   <li>The requested quantity exceeds the medication's current stock.</li>
+     * </ul>
+     * On success, prints a confirmation with the medication name, dispensed amount,
+     * and updated stock level.
+     *
+     * @param inventory the inventory from which to dispense the medication
+     * @param ui        the UI instance (unused directly; output goes via {@code System.out})
+     */
     @Override
     public void execute(Inventory inventory, Ui ui) {
         logger.log(Level.INFO, "Executing DispenseCommand: index={0}, quantity={1}",

--- a/src/main/java/seedu/pharmatracker/command/ListCommand.java
+++ b/src/main/java/seedu/pharmatracker/command/ListCommand.java
@@ -8,13 +8,37 @@ import seedu.pharmatracker.data.Inventory;
 import seedu.pharmatracker.data.Medication;
 import seedu.pharmatracker.ui.Ui;
 
+/**
+ * Command that lists all medications currently in the inventory.
+ *
+ * <p>Prints each medication with a 1-based index, appending a {@code [LOW STOCK]}
+ * flag if the quantity is at or below {@value #LOW_STOCK_THRESHOLD} units.
+ * If the inventory is empty, a single message is printed instead.
+ */
 public class ListCommand extends Command {
+
+    /** Command keyword used to trigger this command. */
     public static final String COMMAND_WORD = "list";
 
+    /** Quantity at or below which a medication is considered low stock. */
     private static final int LOW_STOCK_THRESHOLD = 10;
+
+    /** Visual divider printed between the medication list and the summary footer. */
     private static final String DIVIDER = "------------------------------------------------------";
+
     private static final Logger logger = Logger.getLogger(ListCommand.class.getName());
 
+    /**
+     * Executes the list command by printing all medications in the inventory.
+     *
+     * <p>If the inventory is empty, prints {@code "Inventory is empty."} and returns early.
+     * Otherwise, prints each {@link Medication} with a 1-based index and a
+     * {@code [LOW STOCK]} flag for any medication at or below the low-stock threshold,
+     * followed by the total medication count.
+     *
+     * @param inventory the inventory containing the medications to list
+     * @param ui        the UI instance (unused directly; output goes via {@code System.out})
+     */
     @Override
     public void execute(Inventory inventory, Ui ui) {
         logger.log(Level.INFO, "Executing ListCommand");

--- a/src/test/java/seedu/pharmatracker/command/DispenseCommandTest.java
+++ b/src/test/java/seedu/pharmatracker/command/DispenseCommandTest.java
@@ -13,20 +13,36 @@ import java.io.PrintStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * JUnit tests for {@link DispenseCommand}.
+ *
+ * <p>Redirects {@code System.out} to an in-memory stream before each test
+ * to allow assertion of printed output, and restores the original stream after.
+ */
 public class DispenseCommandTest {
     private final ByteArrayOutputStream out = new ByteArrayOutputStream();
     private final PrintStream original = System.out;
 
+    /**
+     * Redirects {@code System.out} to an in-memory stream before each test.
+     */
     @BeforeEach
     public void setUp() {
         System.setOut(new PrintStream(out));
     }
 
+    /**
+     * Restores {@code System.out} to its original stream after each test.
+     */
     @AfterEach
     public void tearDown() {
         System.setOut(original);
     }
 
+    /**
+     * Tests that a valid dispense operation reduces the medication's
+     * quantity in the inventory by the dispensed amount.
+     */
     @Test
     public void execute_validDispense_reducesQuantity() {
         Inventory inventory = new Inventory();
@@ -36,6 +52,10 @@ public class DispenseCommandTest {
         assertEquals(130, inventory.getMedication(0).getQuantity());
     }
 
+    /**
+     * Tests that a valid dispense operation prints a success message containing
+     * the medication name, dispensed amount, and updated stock level.
+     */
     @Test
     public void execute_validDispense_printsSuccessMessage() {
         Inventory inventory = new Inventory();
@@ -49,6 +69,10 @@ public class DispenseCommandTest {
         assertTrue(output.contains("Updated Stock: 130 units"));
     }
 
+    /**
+     * Tests that dispensing more than the available stock prints an error message
+     * and leaves the inventory quantity unchanged.
+     */
     @Test
     public void execute_quantityExceedsStock_printsError() {
         Inventory inventory = new Inventory();
@@ -59,6 +83,10 @@ public class DispenseCommandTest {
         assertEquals(10, inventory.getMedication(0).getQuantity());
     }
 
+    /**
+     * Tests that dispensing exactly the full stock reduces the quantity to zero
+     * and still prints a success message.
+     */
     @Test
     public void execute_exactStockDispensed_quantityBecomesZero() {
         Inventory inventory = new Inventory();
@@ -69,6 +97,10 @@ public class DispenseCommandTest {
         assertTrue(out.toString().contains("Dispensing successfully!"));
     }
 
+    /**
+     * Tests that providing an index greater than the inventory size prints
+     * an invalid index error message.
+     */
     @Test
     public void execute_invalidIndexTooHigh_printsError() {
         Inventory inventory = new Inventory();
@@ -78,6 +110,10 @@ public class DispenseCommandTest {
         assertTrue(out.toString().contains("Invalid index."));
     }
 
+    /**
+     * Tests that providing an index of zero, which is below the valid 1-based
+     * range, prints an invalid index error message.
+     */
     @Test
     public void execute_invalidIndexZero_printsError() {
         Inventory inventory = new Inventory();

--- a/src/test/java/seedu/pharmatracker/command/ListCommandTest.java
+++ b/src/test/java/seedu/pharmatracker/command/ListCommandTest.java
@@ -14,20 +14,36 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * JUnit tests for {@link ListCommand}.
+ *
+ * <p>Redirects {@code System.out} before each test and restores it after,
+ * allowing assertion of printed output without coupling to the UI layer.
+ */
 public class ListCommandTest {
     private final ByteArrayOutputStream out = new ByteArrayOutputStream();
     private final PrintStream original = System.out;
 
+    /**
+     * Redirects {@code System.out} to an in-memory stream before each test.
+     */
     @BeforeEach
     public void setUp() {
         System.setOut(new PrintStream(out));
     }
 
+    /**
+     * Restores {@code System.out} to its original stream after each test.
+     */
     @AfterEach
     public void tearDown() {
         System.setOut(original);
     }
 
+    /**
+     * Tests that executing {@link ListCommand} on an empty inventory
+     * prints the empty-inventory message.
+     */
     @Test
     public void execute_emptyInventory_printsEmptyMessage() {
         Inventory inventory = new Inventory();
@@ -36,6 +52,10 @@ public class ListCommandTest {
         assertEquals("Inventory is empty.", out.toString().trim());
     }
 
+    /**
+     * Tests that executing {@link ListCommand} with a single medication
+     * prints all fields: name, dosage, quantity, expiry date, and tag.
+     */
     @Test
     public void execute_singleMedication_printsMedicationDetails() {
         Inventory inventory = new Inventory();
@@ -50,6 +70,10 @@ public class ListCommandTest {
         assertTrue(output.contains("pain"));
     }
 
+    /**
+     * Tests that executing {@link ListCommand} with multiple medications
+     * prints each entry with a 1-based index prefix.
+     */
     @Test
     public void execute_multipleMedications_printsAllWithIndex() {
         Inventory inventory = new Inventory();
@@ -64,6 +88,10 @@ public class ListCommandTest {
         assertTrue(output.contains("Paracetamol"));
     }
 
+    /**
+     * Tests that a medication with an empty tag string does not produce
+     * a "Tag:" line in the output.
+     */
     @Test
     public void execute_medicationWithEmptyTag_noTagInOutput() {
         Inventory inventory = new Inventory();
@@ -73,6 +101,10 @@ public class ListCommandTest {
         assertFalse(out.toString().contains("| Tag:"));
     }
 
+    /**
+     * Tests that executing {@link ListCommand} on a non-empty inventory
+     * prints both the inventory header and the total medication count footer.
+     */
     @Test
     public void execute_nonEmptyInventory_printsHeaderAndFooter() {
         Inventory inventory = new Inventory();
@@ -84,6 +116,10 @@ public class ListCommandTest {
         assertTrue(output.contains("Total Medications: 1"));
     }
 
+    /**
+     * Tests that a medication below the low-stock threshold is flagged
+     * with {@code [LOW STOCK]} in the output.
+     */
     @Test
     public void execute_lowStockMedication_printsLowStockFlag() {
         Inventory inventory = new Inventory();
@@ -93,6 +129,10 @@ public class ListCommandTest {
         assertTrue(out.toString().contains("[LOW STOCK]"));
     }
 
+    /**
+     * Tests that a medication above the low-stock threshold does not
+     * produce a {@code [LOW STOCK]} flag in the output.
+     */
     @Test
     public void execute_normalStockMedication_noLowStockFlag() {
         Inventory inventory = new Inventory();
@@ -102,6 +142,10 @@ public class ListCommandTest {
         assertFalse(out.toString().contains("[LOW STOCK]"));
     }
 
+    /**
+     * Tests that the total medication count in the footer reflects the
+     * exact number of medications added to the inventory.
+     */
     @Test
     public void execute_multipleMedications_correctTotalCount() {
         Inventory inventory = new Inventory();


### PR DESCRIPTION
## What this PR does
Adds Javadoc comments to `ListCommand`, `DispenseCommand`,
`ListCommandTest`, and `DispenseCommandTest`.

## Changes
- Class-level Javadoc for all four files
- Method-level Javadoc for `execute()` and constructors
- Field-level Javadoc for non-obvious constants and instance variables
