### PR TITLE
More PE-D bug fixes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -530,7 +530,7 @@ PharmaTracker Customers:
 1. [C001] John Tan | Phone: 99887766
 2. [C002] Mary Tan | Phone: 87654321 | Address: 10 Orchard Road
 3. [C003] David Ng | Phone: 93456789 | Allergies: penicillin
-3. [C003] El Primo | Phone: 64363459 | Address: 10 Orchard Road | Allergies: penicillin
+4. [C004] El Primo | Phone: 64363459 | Address: 10 Orchard Road | Allergies: penicillin
 ------------------------------------------------------
 Total Customers: 3.
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -516,17 +516,19 @@ ____________________________________________________________
 ### List all customers: `list-customers`
 
 Displays a numbered list of all customers currently registered in the system,
-showing their customer ID, name, and phone number.
+showing their customer ID, name, and phone number. If available, each entry
+also includes the customer's address and recorded allergies.
 
 **Format**: `list-customers`
 
-**Example — 3 customers registered:**
+**Example — 4 customers registered:**
 
 ```
 PharmaTracker Customers:
 1. [C001] John Tan | Phone: 99887766
-2. [C002] Mary Tan | Phone: 87654321
-3. [C003] David Ng | Phone: 93456789
+2. [C002] Mary Tan | Phone: 87654321 | Address: 10 Orchard Road
+3. [C003] David Ng | Phone: 93456789 | Allergies: penicillin
+3. [C003] El Primo | Phone: 64363459 | Address: 10 Orchard Road | Allergies: penicillin
 ------------------------------------------------------
 Total Customers: 3.
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -137,7 +137,8 @@ Displays a high-level summary of all medications currently stored in the system.
 **Format**: `list`
 
 * Shows a numbered list of all medication records currently in the inventory.
-* Each entry displays the name, dosage, current quantity, and expiry date.
+* Each entry displays labels in this format: `Name: ... | Dosage: ... | Qty: ... | Exp: ...`.
+* Optional fields (e.g. `Tag`, `Dosage Form`, `Manufacturer`, `Directions`, `Frequency`, `Route`, `Maximum Daily Dosage`) are shown inline when present.
 * Medications with a quantity of **less than 20** are automatically flagged with `[LOW STOCK]` (consistent with the default threshold for the `lowstock` command).
 * This list provides the **INDEX** values required for other commands such as `delete`, `view`, and `dispense`.
 
@@ -147,11 +148,12 @@ Displays a high-level summary of all medications currently stored in the system.
 **Expected Output**:
 ```
 PharmaTracker Inventory:
-1. Amoxicillin | 250mg | Qty: 50  | Expiry: 01/06/2025
-2. Ibuprofen   | 200mg | Qty: 5   | Expiry: 15/06/2026 [LOW STOCK]
-3. Paracetamol | 500mg | Qty: 150 | Expiry: 31/12/2026
+1. Name: Amoxicillin | Dosage: 250mg | Qty: 50 | Exp: 2025-06-01 | Tag: antibiotic
+2. Name: Ibuprofen | Dosage: 200mg | Qty: 5 | Exp: 2026-06-15 | Tag: painkiller [LOW STOCK]
+3. Name: Paracetamol | Dosage: 500mg | Qty: 150 | Exp: 2026-12-31 | Tag: painkiller
 ------------------------------------------------------
 Total Medications: 3
+Low Stock Alerts: 1 medication(s) need restocking.
 ```
 ---
 

--- a/src/main/java/seedu/pharmatracker/PharmaTracker.java
+++ b/src/main/java/seedu/pharmatracker/PharmaTracker.java
@@ -9,7 +9,11 @@ import seedu.pharmatracker.auth.AuthService;
 import seedu.pharmatracker.logger.LoggerSetup;
 
 import seedu.pharmatracker.command.Command;
+import seedu.pharmatracker.command.ExitCommand;
+import seedu.pharmatracker.command.HelpCommand;
+import seedu.pharmatracker.command.LoginCommand;
 import seedu.pharmatracker.command.LogoutCommand;
+import seedu.pharmatracker.command.RegisterCommand;
 import seedu.pharmatracker.data.Inventory;
 import seedu.pharmatracker.core.AppServices;
 import seedu.pharmatracker.storage.Storage;
@@ -69,6 +73,13 @@ public class PharmaTracker {
         while (true) {
             String fullCommand = ui.readCommand();
             try {
+                String commandWord = extractCommandWord(fullCommand);
+                if (shouldBlockBeforeParsing(commandWord)) {
+                    ui.printMessage("Authentication required. Use: register USERNAME /p PASSWORD or "
+                            + "login USERNAME /p PASSWORD");
+                    continue;
+                }
+
                 Command c = parse(fullCommand);
                 if (c != null) {
                     if (c.requiresAuthentication() && !authService.isAuthenticated()) {
@@ -100,6 +111,54 @@ public class PharmaTracker {
                 ui.printMessage(e.getMessage());
             }
         }
+    }
+
+    /**
+     * Extracts the lowercase command word from raw user input.
+     *
+     * @param fullCommand Raw command entered by the user.
+     * @return Lowercase command word, or empty string if input is blank.
+     */
+    private String extractCommandWord(String fullCommand) {
+        if (fullCommand == null) {
+            return "";
+        }
+
+        String trimmed = fullCommand.trim();
+        if (trimmed.isEmpty()) {
+            return "";
+        }
+
+        String[] inputParts = trimmed.split("\\s+", 2);
+        return inputParts[0].toLowerCase();
+    }
+
+    /**
+     * Returns true when an unauthenticated user should be blocked before parsing.
+     *
+     * @param commandWord Lowercase command word extracted from input.
+     * @return True if authentication is required before parser-level validation.
+     */
+    private boolean shouldBlockBeforeParsing(String commandWord) {
+        if (authService.isAuthenticated()) {
+            return false;
+        }
+
+        return !isPublicCommand(commandWord);
+    }
+
+    /**
+     * Returns true if the command can be used while unauthenticated.
+     *
+     * @param commandWord Lowercase command word.
+     * @return True for commands that remain available before login.
+     */
+    private boolean isPublicCommand(String commandWord) {
+        return RegisterCommand.COMMAND_WORD.equals(commandWord)
+                || LoginCommand.COMMAND_WORD.equals(commandWord)
+                || HelpCommand.COMMAND_WORD.equals(commandWord)
+                || ExitCommand.COMMAND_WORD.equals(commandWord)
+                || LogoutCommand.COMMAND_WORD.equals(commandWord);
     }
 
     /**


### PR DESCRIPTION
## Summary
Updates the User Guide so the `list-customers` command documentation matches the actual application output.

## Problem
UG stated that `list-customers` shows only customer ID, name, and phone number, but actual output also includes `Address` and `Allergies` when those fields are available.

## Changes Made
- Updated the `list-customers` description to explicitly state that optional address and allergy fields are displayed when present.
- Updated the example output block to include:
  - one customer entry showing `Address`
  - one customer entry showing `Allergies`

## Why
This removes misleading documentation for an index-based customer workflow and keeps UG behavior consistent with runtime output.

## Issue
Fixes #201