### PR TITLE
Limit auto-restock alert summary to startup and list flow

### DIFF
--- a/src/main/java/seedu/pharmatracker/PharmaTracker.java
+++ b/src/main/java/seedu/pharmatracker/PharmaTracker.java
@@ -11,6 +11,7 @@ import seedu.pharmatracker.logger.LoggerSetup;
 import seedu.pharmatracker.command.Command;
 import seedu.pharmatracker.command.ExitCommand;
 import seedu.pharmatracker.command.HelpCommand;
+import seedu.pharmatracker.command.ListCommand;
 import seedu.pharmatracker.command.LoginCommand;
 import seedu.pharmatracker.command.LogoutCommand;
 import seedu.pharmatracker.command.RegisterCommand;
@@ -66,6 +67,10 @@ public class PharmaTracker {
         ui.printWelcomeMessage();
         if (authService.isAuthenticated()) {
             ui.printMessage("Restored session for user: " + authService.getCurrentUsername());
+            ArrayList<RestockAlert> activeAlerts = restockAlertService.getActiveAlerts();
+            if (!activeAlerts.isEmpty()) {
+                ui.printAutoRestockAlertSummary(activeAlerts);
+            }
         } else {
             ui.printMessage("Please login or register to use PharmaTracker features.");
         }
@@ -99,7 +104,7 @@ public class PharmaTracker {
                     storage.saveSession(authService.getCurrentUsername());
                     storage.saveAlertHistory(restockAlertService.getAlertHistory());
 
-                    if (authService.isAuthenticated()) {
+                    if (authService.isAuthenticated() && c instanceof ListCommand) {
                         ArrayList<RestockAlert> activeAlerts = restockAlertService.getActiveAlerts();
                         if (!activeAlerts.isEmpty()) {
                             ui.printAutoRestockAlertSummary(activeAlerts);


### PR DESCRIPTION
## Summary
This PR fixes noisy auto-restock alert printing by restricting when the summary is shown.

## What changed
1. Moved auto-restock summary printing to startup immediately after the authentication status message.
2. Removed unconditional post-command summary printing.
3. Added a guard so the summary is printed only after executing the `list` command (when authenticated).

## Why
Previously, active alerts were printed after every successful command because the print call lived in the shared post-command path.
This produced repetitive output unrelated to the user’s action.

## Resulting behavior
1. On app startup: summary is printed once (if authenticated and active alerts exist).
2. On `list`: summary is printed (if authenticated and active alerts exist).
3. Other commands: no auto-restock summary spam.

## Scope
No changes to alert generation, acknowledgement, or persistence logic; only alert summary display timing was adjusted.