### PR TITLE
Include date and explicit quantity label in customer dispensing history

### DIFF
--- a/src/main/java/seedu/pharmatracker/command/DispenseCommand.java
+++ b/src/main/java/seedu/pharmatracker/command/DispenseCommand.java
@@ -2,6 +2,7 @@ package seedu.pharmatracker.command;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -22,6 +23,7 @@ public class DispenseCommand extends Command {
 
     private static final int NO_CUSTOMER = -1;
     private static final int MIN_QUANTITY = 1;
+    private static final DateTimeFormatter HISTORY_DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
     private static final Logger logger = Logger.getLogger(DispenseCommand.class.getName());
 
@@ -185,7 +187,9 @@ public class DispenseCommand extends Command {
         String dosage = (med.getDosage() != null && !med.getDosage().isEmpty())
                 ? med.getDosage()
                 : "N/A";
-        String record = med.getName() + " | " + dosage + " | Qty: " + quantity;
+        String record = med.getName() + " | " + dosage
+            + " | Qty dispensed: " + quantity
+            + " | Date: " + LocalDate.now().format(HISTORY_DATE_FORMAT);
         customer.addDispensingHistory(record);
 
         logger.log(Level.INFO, "Linked dispense to customer: {0}", customer.getName());

--- a/src/test/java/seedu/pharmatracker/command/ViewCustomerCommandTest.java
+++ b/src/test/java/seedu/pharmatracker/command/ViewCustomerCommandTest.java
@@ -12,6 +12,8 @@ import seedu.pharmatracker.ui.Ui;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -249,6 +251,8 @@ public class ViewCustomerCommandTest {
         new ViewCustomerCommand(1).execute(inventory, new Ui(), customerList);
         String output = out.toString();
         assertTrue(output.contains("Paracetamol"));
+        assertTrue(output.contains("Qty dispensed: 10"));
+        assertTrue(output.contains("Date: " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy"))));
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR updates customer dispensing history entries to include both a clear quantity label and dispense date.

## Problem
`view-customer` history output did not match documented behavior. Entries lacked date and used less explicit quantity wording.

## What changed
- Updated dispense history record format to include:
  - `Qty dispensed: N`
  - `Date: DD/MM/YYYY`
- Added/updated tests to verify history output includes quantity label and date.

## Why this fix
This aligns actual output with the user-facing guide and improves readability of customer medication history.

## Testing
- Ran dispense and view-customer related tests.
- Confirmed expected history output assertions pass.

## Issue
Closes #194 