### PR TITLE
Fix dispense to reject non-positive customer index

### DIFF
--- a/src/main/java/seedu/pharmatracker/parser/PharmaTrackerParser.java
+++ b/src/main/java/seedu/pharmatracker/parser/PharmaTrackerParser.java
@@ -109,6 +109,10 @@ public class PharmaTrackerParser {
                     String customerStr = extractFlagValue(args, "/c", null);
                     if (customerStr != null && !customerStr.isEmpty()) {
                         int dispenseCustomer = Integer.parseInt(customerStr.trim());
+                        if (dispenseCustomer < 1) {
+                            System.out.println("Invalid customer index. Please enter a valid customer index.");
+                            break;
+                        }
                         return new DispenseCommand(dispenseIndex, dispenseQuantity, dispenseCustomer);
                     }
                 }

--- a/src/test/java/seedu/pharmatracker/parser/PharmaTrackerParserTest.java
+++ b/src/test/java/seedu/pharmatracker/parser/PharmaTrackerParserTest.java
@@ -2,6 +2,7 @@ package seedu.pharmatracker.parser;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
@@ -54,5 +55,11 @@ public class PharmaTrackerParserTest {
     @Test
     public void parser_invalidRegisterFormat_throwsException() {
         assertThrows(PharmaTrackerException.class, () -> PharmaTrackerParser.parse("register alice"));
+    }
+
+    @Test
+    public void parser_dispenseNegativeCustomerIndex_returnsNull() throws PharmaTrackerException {
+        Command c = PharmaTrackerParser.parse("dispense 1 /q 10 /c -1");
+        assertNull(c);
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes a validation gap in `dispense` where non-positive customer index values were accepted in parser flow.

## Problem
Using a non-positive customer index with `dispense` could bypass intended validation behavior and lead to incorrect command handling.

## What changed
- Added parser-side validation to reject customer index values less than 1 when the customer flag is provided.
- Added regression coverage in parser tests for invalid customer index input.

## Why this fix
Validation now matches expected command semantics and prevents invalid customer linkage from entering execution flow.

## Testing
- Ran targeted parser and dispense-related tests.
- Confirmed full test suite passes on the working branch before branch split.

## Issue
Closes #220 