### PR TITLE
Show boundary-style error handling for restock quantity overflow inputs

### DIFF
--- a/src/main/java/seedu/pharmatracker/parser/PharmaTrackerParser.java
+++ b/src/main/java/seedu/pharmatracker/parser/PharmaTrackerParser.java
@@ -210,11 +210,28 @@ public class PharmaTrackerParser {
                 break;
             }
             try {
-                String[] restockParts = description.trim().split("/q");
+                String[] restockParts = description.trim().split("/q", 2);
+                if (restockParts.length != 2) {
+                    System.out.println("Invalid format. Use: restock INDEX /q QUANTITY");
+                    break;
+                }
+
                 int restockIndex = Integer.parseInt(restockParts[0].trim());
-                int restockQuantity = Integer.parseInt(restockParts[1].trim());
+                String restockQuantityRaw = restockParts[1].trim();
+                if (!restockQuantityRaw.matches("-?\\d+")) {
+                    System.out.println("Invalid format. Use: restock INDEX /q QUANTITY");
+                    break;
+                }
+
+                int restockQuantity;
+                try {
+                    restockQuantity = Integer.parseInt(restockQuantityRaw);
+                } catch (NumberFormatException e) {
+                    System.out.println("Quantity to restock must be between 1 and 100000.");
+                    break;
+                }
                 return new RestockCommand(restockIndex, restockQuantity);
-            } catch (Exception e) {
+            } catch (NumberFormatException e) {
                 System.out.println("Invalid format. Use: restock INDEX /q QUANTITY");
                 break;
             }

--- a/src/test/java/seedu/pharmatracker/parser/PharmaTrackerParserTest.java
+++ b/src/test/java/seedu/pharmatracker/parser/PharmaTrackerParserTest.java
@@ -2,6 +2,7 @@ package seedu.pharmatracker.parser;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
@@ -54,5 +55,17 @@ public class PharmaTrackerParserTest {
     @Test
     public void parser_invalidRegisterFormat_throwsException() {
         assertThrows(PharmaTrackerException.class, () -> PharmaTrackerParser.parse("register alice"));
+    }
+
+    @Test
+    public void parser_restockOverflowQuantity_returnsNull() throws PharmaTrackerException {
+        Command c = PharmaTrackerParser.parse("restock 1 /q 2222222222222222222");
+        assertNull(c);
+    }
+
+    @Test
+    public void parser_restockNonNumericQuantity_returnsNull() throws PharmaTrackerException {
+        Command c = PharmaTrackerParser.parse("restock 1 /q abc");
+        assertNull(c);
     }
 }


### PR DESCRIPTION
## Summary
This PR improves `restock` parsing so oversized numeric inputs are handled with quantity-boundary behavior instead of only generic format feedback.

## Problem
Very large `restock` quantity values caused parse failure path behavior that was less consistent with normal quantity validation messaging.

## What changed
- Hardened `restock` parsing for malformed and overflow quantity inputs.
- Added parser regression tests for:
  - extremely large quantity values
  - non-numeric quantity values

## Why this fix
Users now get consistent quantity validation behavior for numeric edge cases, including overflow-like inputs.

## Testing
- Ran parser test suite including new regression cases.
- Verified all parser tests pass.

## Issue
Closes #191 