### PR TITLE
Add parser regression tests for standardized quantity flag usage

### DIFF
--- a/src/test/java/seedu/pharmatracker/parser/PharmaTrackerParserTest.java
+++ b/src/test/java/seedu/pharmatracker/parser/PharmaTrackerParserTest.java
@@ -2,14 +2,17 @@ package seedu.pharmatracker.parser;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.pharmatracker.command.AcknowledgeAlertCommand;
 import seedu.pharmatracker.command.Command;
+import seedu.pharmatracker.command.DispenseCommand;
 import seedu.pharmatracker.command.FindCommand;
 import seedu.pharmatracker.command.LoginCommand;
 import seedu.pharmatracker.command.RegisterCommand;
+import seedu.pharmatracker.command.RestockCommand;
 import seedu.pharmatracker.command.SetThresholdCommand;
 import seedu.pharmatracker.exceptions.PharmaTrackerException;
 
@@ -54,5 +57,29 @@ public class PharmaTrackerParserTest {
     @Test
     public void parser_invalidRegisterFormat_throwsException() {
         assertThrows(PharmaTrackerException.class, () -> PharmaTrackerParser.parse("register alice"));
+    }
+
+    @Test
+    public void parser_dispenseWithSlashQ_returnsDispenseCommand() throws PharmaTrackerException {
+        Command c = PharmaTrackerParser.parse("dispense 1 /q 10");
+        assertTrue(c instanceof DispenseCommand);
+    }
+
+    @Test
+    public void parser_restockWithSlashQ_returnsRestockCommand() throws PharmaTrackerException {
+        Command c = PharmaTrackerParser.parse("restock 1 /q 10");
+        assertTrue(c instanceof RestockCommand);
+    }
+
+    @Test
+    public void parser_dispenseWithLegacyQSlash_returnsNull() throws PharmaTrackerException {
+        Command c = PharmaTrackerParser.parse("dispense 1 q/10");
+        assertNull(c);
+    }
+
+    @Test
+    public void parser_restockWithLegacyQSlash_returnsNull() throws PharmaTrackerException {
+        Command c = PharmaTrackerParser.parse("restock 1 q/10");
+        assertNull(c);
     }
 }


### PR DESCRIPTION
## Summary
This PR adds regression tests to lock in quantity flag consistency behavior across commands.

## Problem
There was concern about inconsistent quantity flag usage and potential acceptance of legacy or incorrect flag forms.

## What changed
- Added parser tests that confirm `/q` syntax is accepted.
- Added parser tests that confirm legacy `q/` syntax is rejected.

## Why this fix
This protects command syntax consistency and prevents regressions in future parser changes.

## Testing
- Ran parser tests with the new flag-consistency cases.
- Verified all related tests pass.

## Issue
Closes #193 